### PR TITLE
chore: update numerals assessment

### DIFF
--- a/js-numerals/README.md
+++ b/js-numerals/README.md
@@ -6,8 +6,8 @@ For example:
 <pre>
 7       === seven
 42      === forty-two
+1999    === one thousand nine hundred and ninety-nine
 2001    === two thousand and one
-1999    === nineteen hundred and ninety-nine
 17999   === seventeen thousand nine hundred and ninety-nine
 342251  === three hundred and forty-two thousand two hundred and fifty-one
 1300420 === one million three hundred thousand four hundred and twenty
@@ -21,6 +21,8 @@ Treat this task like a project to create a real-life application, focus on other
 - Don't use external libraries for the conversion.
 - Make the solution pleasant to look at and user friendly in as many aspects as you can.
 - Commit the important milestones and not just the final result.
-- Don't forget to write tests.
+- Don't forget to write tests. We expect the tests to check also the examples above.
+- Try to support numbers as high as you can.
+- (Optional) Try to support British English counting where numbers between 1000 and 2000 are said out using "hundreds". E.g. 1999 === nineteen hundred and ninety-nine
 
 Thank you for your time and happy coding! 🧑‍💻


### PR DESCRIPTION
In this PR we have removed the expectation for British English numerals as many applicants do not have English as their mother tounge and it causes confusion in many cases. Instead, the British English numerals were added as an optional.

We have also put more emphasis on the available examples.

We have also put more emphasis on trying to support higher numbers.